### PR TITLE
Will toggle names

### DIFF
--- a/jumbohack2025/src/app/mapview/[eventID]/mapview.css
+++ b/jumbohack2025/src/app/mapview/[eventID]/mapview.css
@@ -1,19 +1,49 @@
 .mapContainer {
-    width: 100vw;
-    height: 65vh;
-    position: relative;
+  width: 100vw;
+  height: 65vh;
+  position: relative;
 }
 
 .saveLocationButton {
-    bottom: "20px";
-    right: "20px";
-    padding: "10px 20px";
-    z-index: 100;
-    cursor: "pointer";
-  }
+  bottom: "20px";
+  right: "20px";
+  padding: "10px 20px";
+  z-index: 100;
+  cursor: "pointer";
+}
 
 .fullMapContainer {
-  width:100vw;
-  height:100vh;
-  position: absolute;
+width:100vw;
+height:100vh;
+position: absolute;
+}
+
+/* Styling for club name labels */
+.club-label-popup .mapboxgl-popup-content {
+background: rgba(35, 57, 74, 0.8);
+padding: 5px 10px;
+border-radius: 4px;
+font-size: 12px;
+text-align: center;
+color: white;
+box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Remove the popup tip/arrow */
+.club-label-popup .mapboxgl-popup-tip {
+display: none;
+}
+
+/* Styling for club label text */
+.club-label {
+font-weight: 500;
+white-space: nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
+max-width: 150px;
+}
+
+/* Fix for toggle button z-index when popup is active */
+.fixed.inset-0 {
+z-index: 1000; /* Higher than other elements */
 }

--- a/jumbohack2025/src/app/mapview/[eventID]/mapview.css
+++ b/jumbohack2025/src/app/mapview/[eventID]/mapview.css
@@ -13,37 +13,37 @@
 }
 
 .fullMapContainer {
-width:100vw;
-height:100vh;
-position: absolute;
+  width:100vw;
+  height:100vh;
+  position: absolute;
 }
 
 /* Styling for club name labels */
 .club-label-popup .mapboxgl-popup-content {
-background: rgba(35, 57, 74, 0.8);
-padding: 5px 10px;
-border-radius: 4px;
-font-size: 12px;
-text-align: center;
-color: white;
-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  background: rgba(35, 57, 74, 0.8);
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  text-align: center;
+  color: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 /* Remove the popup tip/arrow */
 .club-label-popup .mapboxgl-popup-tip {
-display: none;
+  display: none;
 }
 
 /* Styling for club label text */
 .club-label {
-font-weight: 500;
-white-space: nowrap;
-overflow: hidden;
-text-overflow: ellipsis;
-max-width: 150px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
 }
 
 /* Fix for toggle button z-index when popup is active */
 .fixed.inset-0 {
-z-index: 1000; /* Higher than other elements */
+  z-index: 1000; /* Higher than other elements */
 }

--- a/jumbohack2025/src/app/mapview/[eventID]/page.tsx
+++ b/jumbohack2025/src/app/mapview/[eventID]/page.tsx
@@ -27,6 +27,11 @@ interface ClubInfo {
   description: string;
 }
 
+interface MarkerWithLabel {
+  marker: mapboxgl.Marker;
+  label?: mapboxgl.Popup;
+}
+
 mapboxgl.accessToken = "pk.eyJ1Ijoic2FsbW9uLXN1c2hpIiwiYSI6ImNtN2dqYWdrZzA4ZnIyam9qNWx1NnAybjcifQ._YD8GYWPtpZ09AwYHzR2Og";
 
 const INITIAL_LONG = -71.120;
@@ -41,7 +46,7 @@ export default function MapboxMap() {
 
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
-  const markersRef = useRef<mapboxgl.Marker[]>([]);
+  const markersRef = useRef<MarkerWithLabel[]>([]); // Updated to include labels
 
   const [long, setLong] = useState(INITIAL_LONG);
   const [lat, setLat] = useState(INITIAL_LAT);
@@ -55,6 +60,7 @@ export default function MapboxMap() {
   const [clubInfo, setClubInfo] = useState<ClubInfo | null>(null);
   const [showClubInfo, setShowClubInfo] = useState(false);
   const [search, setSearch] = useState("");
+  const [showLabels, setShowLabels] = useState(true); // New state for toggle
 
   const getClubByCoords = async (lng: number, lat: number) => {
     try {
@@ -100,143 +106,254 @@ export default function MapboxMap() {
     }
   }, [id]);
 
+  // Function to toggle label visibility based on current state
+  const toggleLabels = () => {
+    const newShowLabels = !showLabels;
+    setShowLabels(newShowLabels);
+    updateLabelsVisibility(newShowLabels);
+  };
+
+  // Function to update all labels visibility
+  const updateLabelsVisibility = (visible: boolean) => {
+    markersRef.current.forEach(({ label }) => {
+      if (label) {
+        if (visible) {
+          label.addTo(mapRef.current!);
+        } else {
+          label.remove();
+        }
+      }
+    });
+  };
+
+  // Check if labels should be shown based on zoom level and proximity
+  const shouldShowLabelsAtZoom = (currentZoom: number) => {
+    // Only show labels if zoom is high enough (less cluttered)
+    return currentZoom >= 16;
+  };
+  
+  // Calculate if markers are too close to each other
+  const checkMarkerProximity = () => {
+    if (!mapRef.current) return;
+    
+    const markers = markersRef.current;
+    const tooCloseThreshold = 100; // pixel distance threshold
+    
+    // Create a map to track which markers should hide their labels
+    const shouldHideLabel = new Map<mapboxgl.Marker, boolean>();
+    markers.forEach(({ marker }) => shouldHideLabel.set(marker, false));
+    
+    // Check each pair of markers for proximity
+    for (let i = 0; i < markers.length; i++) {
+      for (let j = i + 1; j < markers.length; j++) {
+        const markerA = markers[i].marker;
+        const markerB = markers[j].marker;
+        
+        // Convert coordinates to pixel positions
+        const posA = mapRef.current.project(markerA.getLngLat());
+        const posB = mapRef.current.project(markerB.getLngLat());
+        
+        // Calculate pixel distance
+        const distance = Math.sqrt(
+          Math.pow(posA.x - posB.x, 2) + Math.pow(posA.y - posB.y, 2)
+        );
+        
+        // If markers are too close, hide their labels
+        if (distance < tooCloseThreshold) {
+          shouldHideLabel.set(markerA, true);
+          shouldHideLabel.set(markerB, true);
+        }
+      }
+    }
+    
+    // Apply visibility based on proximity check
+    markers.forEach(({ marker, label }) => {
+      if (label) {
+        if (shouldHideLabel.get(marker)) {
+          label.remove();
+        } else if (showLabels && shouldShowLabelsAtZoom(mapRef.current!.getZoom())) {
+          label.addTo(mapRef.current!);
+        }
+      }
+    });
+  };
+
   // Initialize the map
   useEffect(() => {
     if (!mapContainerRef.current) return;
 
     const initializeMap = async () => {
-      const updateMap = async () => {
-        try {
-          console.log("Fetching map location for this event:", id);
-          
-          const response = await fetch("/api/getEventLocation", {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                eventID: id
-              })
-          });
-  
-          if (!response.ok) {
-              console.error("Error fetching map location:", response.status);
-              return;
-          }
-  
-          const data = await response.json();
-  
-          if (data.location) {
-            setLong(data.location.x);
-            setLat(data.location.y);
-            console.log("UPDATED MAP POSITION")
-          }
-          if (data.scale) {
-            setZoom(data.scale);
-          }
-  
-          return data;
-        } catch(error) {
-          console.error("Error fetching map location:", error);
-          return [];
-        }
-      };
-  
-      // Get updated coordinates first
-      const locationData = await updateMap();
-      
-      // Use the fetched coordinates directly instead of using state
-      let mapLong = long;
-      let mapLat = lat;
-      let mapZoom = zoom;
-      
-      if (locationData && locationData.location) {
-        mapLong = locationData.location.x;
-        mapLat = locationData.location.y;
-        console.log("UPDATED MAP POSITION to:", mapLong, mapLat);
+      try {
+        console.log("Fetching map location for this event:", id);
         
-        // Also update state for other components that might need it
-        setLong(mapLong);
-        setLat(mapLat);
-      }
-      
-      if (locationData && locationData.scale) {
-        mapZoom = locationData.scale;
-        setZoom(mapZoom);
-      }
-
-      // Create map with directly fetched coordinates
-      const map = new mapboxgl.Map({
-        container: mapContainerRef.current!,
-        style: "mapbox://styles/mapbox/dark-v11",
-        center: [mapLong, mapLat], // Use direct variables, not state
-        zoom: mapZoom, // Use direct variable, not state
-      });
-      mapRef.current = map;
-
-      const getExistingClubs = async () => {
-        try {
-          const response = await fetch("/api/getExistingClubs", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ eventID: id }),
-          });
-
-          if (!response.ok) {
-            console.error("Error fetching existing clubs.");
-          }
-
-          return await response.json();
-        } catch (error) {
-          console.error("Error fetching clubs:", error);
-        }
-      };
-
-      map.on("load", async () => {
-        const existingClubs: Club[] = await getExistingClubs();
-        setClubs(existingClubs);
-        setQueue(existingClubs);
-
-        const uniqueCategories = [...new Set(existingClubs.map((club) => club.category))];
-        setCategories(uniqueCategories);
-
-        existingClubs.forEach((club) => {
-          if (!club.coordinates) return;
-
-          const marker = new mapboxgl.Marker()
-            .setLngLat([club.coordinates.x, club.coordinates.y])
-            .addTo(map);
-
-          marker.getElement().addEventListener("click", async (event) => {
-            event.stopPropagation();
-            const { lng, lat } = marker.getLngLat();
-            const club = await getClubByCoords(lng, lat);
-            if (club) {
-              setClubInfo({ id: club.id, name: club.name, description: club.description });
-              setShowClubInfo(true);
-            }
-          });
-
-          markersRef.current.push(marker);
+        const response = await fetch("/api/getEventLocation", {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              eventID: id
+            })
         });
-      });
 
-      // Update state when moving the map
-      map.on("move", () => {
-        const mapCenter = map.getCenter();
-        setLong(mapCenter.lng);
-        setLat(mapCenter.lat);
-        setZoom(map.getZoom());
-      });
+        if (!response.ok) {
+            console.error("Error fetching map location:", response.status);
+            return;
+        }
 
-      return () => {
-        map.remove();
-      };
+        const data = await response.json();
+        
+        // Use the fetched coordinates directly
+        let mapLong = long;
+        let mapLat = lat;
+        let mapZoom = zoom;
+        
+        if (data.location) {
+          mapLong = data.location.x;
+          mapLat = data.location.y;
+          console.log("UPDATED MAP POSITION to:", mapLong, mapLat);
+          
+          // Update state for other components
+          setLong(mapLong);
+          setLat(mapLat);
+        }
+        
+        if (data.scale) {
+          mapZoom = data.scale;
+          setZoom(mapZoom);
+        }
+
+        // Create map with directly fetched coordinates
+        const map = new mapboxgl.Map({
+          container: mapContainerRef.current!,
+          style: "mapbox://styles/mapbox/dark-v11",
+          center: [mapLong, mapLat],
+          zoom: mapZoom,
+        });
+        mapRef.current = map;
+
+        const getExistingClubs = async () => {
+          try {
+            const response = await fetch("/api/getExistingClubs", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ eventID: id }),
+            });
+
+            if (!response.ok) {
+              console.error("Error fetching existing clubs.");
+            }
+
+            return await response.json();
+          } catch (error) {
+            console.error("Error fetching clubs:", error);
+            return [];
+          }
+        };
+
+        map.on("load", async () => {
+          const existingClubs: Club[] = await getExistingClubs();
+          setClubs(existingClubs);
+          setQueue(existingClubs);
+
+          const uniqueCategories = [...new Set(existingClubs.map((club) => club.category))];
+          setCategories(uniqueCategories);
+
+          // Clear existing markers
+          markersRef.current.forEach(({ marker, label }) => {
+            marker.remove();
+            if (label) label.remove();
+          });
+          markersRef.current = [];
+
+          // Create new markers with labels
+          existingClubs.forEach((club) => {
+            if (!club.coordinates) return;
+
+            const marker = new mapboxgl.Marker()
+              .setLngLat([club.coordinates.x, club.coordinates.y])
+              .addTo(map);
+
+            // Create a popup for the club name
+            const popup = new mapboxgl.Popup({
+              closeButton: false,
+              closeOnClick: false,
+              offset: [0, -30], // Offset so it appears above the marker
+              className: 'club-label-popup'
+            })
+              .setLngLat([club.coordinates.x, club.coordinates.y])
+              .setHTML(`<div class="club-label">${club.name}</div>`);
+
+            // Only add the popup if labels are enabled
+            if (showLabels && shouldShowLabelsAtZoom(map.getZoom())) {
+              popup.addTo(map);
+            }
+
+            marker.getElement().addEventListener("click", async (event) => {
+              event.stopPropagation();
+              const { lng, lat } = marker.getLngLat();
+              const club = await getClubByCoords(lng, lat);
+              if (club) {
+                setClubInfo({ id: club.id, name: club.name, description: club.description });
+                setShowClubInfo(true);
+              }
+            });
+
+            markersRef.current.push({ marker, label: popup });
+          });
+        });
+
+        // Update state when moving the map
+        map.on("move", () => {
+          const mapCenter = map.getCenter();
+          setLong(mapCenter.lng);
+          setLat(mapCenter.lat);
+          setZoom(map.getZoom());
+          
+          // Check for proximity during map movement and update labels
+          if (showLabels) {
+            checkMarkerProximity();
+          } else {
+            // Ensure labels are hidden when toggle is off
+            markersRef.current.forEach(({ label }) => {
+              if (label) label.remove();
+            });
+          }
+        });
+
+        // Update label visibility when zoom changes
+        map.on("zoom", () => {
+          const currentZoom = map.getZoom();
+          
+          // If labels are enabled in UI, check zoom level and proximity
+          if (showLabels) {
+            const shouldShow = shouldShowLabelsAtZoom(currentZoom);
+            if (shouldShow) {
+              checkMarkerProximity();
+            } else {
+              // Hide all labels when zoom is too low
+              markersRef.current.forEach(({ label }) => {
+                if (label) label.remove();
+              });
+            }
+          } else {
+            // Ensure labels are hidden when toggle is off during zoom
+            markersRef.current.forEach(({ label }) => {
+              if (label) label.remove();
+            });
+          }
+        });
+
+        return () => {
+          map.remove();
+        };
+      } catch (error) {
+        console.error("Error initializing map:", error);
+      }
     };
 
     initializeMap();
   }, [id]); // Only re-run on ID change
 
   // Compute filtered clubs based on the search input and current category.
-  // When search is empty, all clubs are shown.
   const filteredClubs = selectedCategory === ""? clubs.filter((club) =>
     club.name.toLowerCase().includes(search.toLowerCase())
   ): clubs.filter((club) =>
@@ -249,8 +366,11 @@ export default function MapboxMap() {
     if (!mapRef.current) return;
 
     const updateMarkers = () => {
-      // Remove existing markers
-      markersRef.current.forEach((marker) => marker.remove());
+      // Remove existing markers and labels
+      markersRef.current.forEach(({ marker, label }) => {
+        marker.remove();
+        if (label) label.remove();
+      });
       markersRef.current = [];
 
       // Add a marker for each club in the filtered list
@@ -263,6 +383,21 @@ export default function MapboxMap() {
         const marker = new mapboxgl.Marker()
           .setLngLat([lng, lat])
           .addTo(mapRef.current!);
+
+        // Create a popup for the club name
+        const popup = new mapboxgl.Popup({
+          closeButton: false,
+          closeOnClick: false,
+          offset: [0, -30], // Offset so it appears above the marker
+          className: 'club-label-popup'
+        })
+          .setLngLat([lng, lat])
+          .setHTML(`<div class="club-label">${club.name}</div>`);
+
+        // Only add the popup if labels are enabled and zoom is appropriate
+        if (showLabels && shouldShowLabelsAtZoom(mapRef.current!.getZoom())) {
+          popup.addTo(mapRef.current!);
+        }
 
         // Attach click event to marker
         marker.getElement().addEventListener("click", async (event) => {
@@ -279,7 +414,7 @@ export default function MapboxMap() {
           }
         });
 
-        markersRef.current.push(marker);
+        markersRef.current.push({ marker, label: popup });
       });
     };
 
@@ -292,9 +427,26 @@ export default function MapboxMap() {
       };
     } else {
       updateMarkers();
-      return undefined;
     }
-  }, [filteredClubs]);
+  }, [filteredClubs, showLabels]);
+
+  // Effect to update label visibility when the showLabels state changes
+  useEffect(() => {
+    if (!mapRef.current || !mapRef.current.loaded()) return;
+    
+    if (showLabels) {
+      const currentZoom = mapRef.current.getZoom();
+      if (shouldShowLabelsAtZoom(currentZoom)) {
+        // Check proximity before showing labels
+        checkMarkerProximity();
+      }
+    } else {
+      // When labels are disabled, ensure all labels are removed
+      markersRef.current.forEach(({ label }) => {
+        if (label) label.remove();
+      });
+    }
+  }, [showLabels]);
 
   // Update queue when category is selected
   useEffect(() => {
@@ -312,54 +464,6 @@ export default function MapboxMap() {
             (club.y === undefined || club.y === null))
       );
       setQueue(filteredQueue);
-
-      const updateMarkers = () => {
-        // Remove existing markers
-        markersRef.current.forEach((marker) => marker.remove());
-        markersRef.current = [];
-
-        // Add a marker for each club in the filtered list
-        filteredQueue.forEach((club) => {
-          // Determine coordinates (supports both club.coordinates and club.x/club.y)
-          const lng = club.coordinates ? club.coordinates.x : club.x;
-          const lat = club.coordinates ? club.coordinates.y : club.y;
-          if (lng == null || lat == null) return; // Skip if no coordinates
-
-          const marker = new mapboxgl.Marker()
-            .setLngLat([lng, lat])
-            .addTo(mapRef.current!);
-
-          // Attach click event to marker
-          marker.getElement().addEventListener("click", async (event) => {
-            event.stopPropagation();
-            const { lng, lat } = marker.getLngLat();
-            const clubData = await getClubByCoords(lng, lat);
-            if (clubData) {
-              setClubInfo({
-                id: clubData.id,
-                name: clubData.name,
-                description: clubData.description,
-              });
-              setShowClubInfo(true);
-            }
-          });
-
-          markersRef.current.push(marker);
-        });
-      };
-
-      if (!mapRef.current.loaded()) {
-        mapRef.current.on("load", updateMarkers);
-        return () => {
-          // Properly typed cleanup function
-          if (mapRef.current) {
-            mapRef.current.off("load", updateMarkers);
-          }
-        };
-      } else {
-        updateMarkers();
-        return undefined;
-      }
     }
   }, [selectedCategory, clubs]);
 
@@ -383,22 +487,46 @@ export default function MapboxMap() {
       )}
 
       <div className="p-6 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h1 className="text-xl md:text-2xl font-bold mb-4 font-serif">{eventName}</h1>
-
-        <div className="mb-4 w-3/5">
-          <select
-            value={selectedCategory}
-            onChange={(e) => setSelectedCategory(e.target.value)}
-            className="w-full p-3 border shadow text-[#23394A] font-inter bg-[#F7F9FB] focus:ring-2 focus:ring-blue-50"
-          >
-            <option value="">Select a category</option>
-            {categories.map((category) => (
-              <option key={category} value={category}>
-                {category}
-              </option>
-            ))}
-          </select>
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-xl md:text-2xl font-bold font-serif">{eventName}</h1>
         </div>
+
+        <div className="flex flex-col md:flex-row gap-4 mb-4">
+          <div className="w-full md:w-3/5">
+            <select
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="w-full p-3 border shadow text-[#23394A] font-inter bg-[#F7F9FB] focus:ring-2 focus:ring-blue-50"
+            >
+              <option value="">Select a category</option>
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-center bg-white rounded-full shadow px-4 py-2">
+            <span className="mr-2">Show Labels</span>
+            <button
+              className={`relative inline-flex h-6 w-11 items-center rounded-full ${
+                showLabels ? "bg-blue-600" : "bg-gray-200"
+              }`}
+              onClick={toggleLabels}
+              aria-pressed={showLabels}
+              type="button"
+            >
+              <span className="sr-only">Toggle labels</span>
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${
+                  showLabels ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+        
         {/* Queue */}
         <div className="mb-4">
            <ul className="flex flex-row overflow-auto">

--- a/jumbohack2025/src/app/mapview/[eventID]/page.tsx
+++ b/jumbohack2025/src/app/mapview/[eventID]/page.tsx
@@ -440,7 +440,7 @@ export default function MapboxMap() {
           <h1 className="text-xl md:text-2xl font-bold font-serif">{eventName}</h1>
         </div>
 
-        <div className="flex flex-col md:flex-row gap-4 mb-4">
+        <div className="flex flex-col md:flex-row justify-between items-center mb-4">
           <div className="w-full md:w-3/5">
             <select
               value={selectedCategory}
@@ -456,11 +456,11 @@ export default function MapboxMap() {
             </select>
           </div>
 
-          <div className="flex items-center bg-white rounded-full shadow px-4 py-2">
+          <div className="flex items-center bg-categoryBg shadow px-6 py-4 ml-auto">
             <span className="mr-2">Show Labels</span>
             <button
               className={`relative inline-flex h-6 w-11 items-center rounded-full ${
-                showLabels ? "bg-blue-600" : "bg-gray-200"
+                showLabels ? "bg-[#2E73B5]" : "bg-gray-200"
               }`}
               onClick={toggleLabels}
               aria-pressed={showLabels}


### PR DESCRIPTION
It works!

The behavior of the labels is determined by the "Show Labels" toggle. If this toggle is off, the labels never show no matter what. However, if labels are turned on they only appear if they will not overlap with other labels (i.e. the spacing is greater than 100px between two longitude and latitude points). This spacing may not be quite what we want but at least we can now play around with what's been implemented to fine tune our maps. The labels also don't slow down the map much because I the made the label interface so that it stores the club name, lat, long, and label so this avoids having to fetch club data again when recreating labels.

The toggle also matches reasonably well with the figma. To change the look of the labels themselves, use the mapview css file since that's how we were styling the mapbox gl already so I didn't try to use tailwind.

Mapbox gl has a [built-in popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/) which made this a little easier. But a lot of the work went into structuring the labels and also handling the show/hide and proximity logic.

![image](https://github.com/user-attachments/assets/0c766b55-9949-4e9c-8069-9a50e4b5fead)
![image](https://github.com/user-attachments/assets/df1c7094-91df-4200-9622-e7f687eef603)
![image](https://github.com/user-attachments/assets/072c55d9-c96e-4618-a1e7-37f2139b898d)
![image](https://github.com/user-attachments/assets/0df7043f-4b33-45eb-a1bc-65a786b95d3b)
