### PR TITLE
Table Timings (Form & Map View)

### DIFF
--- a/jumbohack2025/src/app/api/event/route.ts
+++ b/jumbohack2025/src/app/api/event/route.ts
@@ -17,8 +17,6 @@ export async function POST(request: Request) {
       creator,
     } = data;
 
-    console.log(data);
-
     const result = await query(
       `INSERT INTO event (name, description, date, location, scale, start_time, end_time, creator) 
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8) 

--- a/jumbohack2025/src/app/api/event/route.ts
+++ b/jumbohack2025/src/app/api/event/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
       description,
       scale,
       startTime,
-      duration,
+      endTime,
       creator,
     } = data;
 
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
         pointString,
         scale,
         startTime,
-        duration,
+        endTime,
         creator
       ]
     );

--- a/jumbohack2025/src/app/api/event/route.ts
+++ b/jumbohack2025/src/app/api/event/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: Request) {
     console.log(data);
 
     const result = await query(
-      `INSERT INTO event (name, description, date, location, scale, start_time, duration, creator) 
+      `INSERT INTO event (name, description, date, location, scale, start_time, end_time, creator) 
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8) 
        RETURNING id`,
       [

--- a/jumbohack2025/src/app/api/getClubByCoords/route.ts
+++ b/jumbohack2025/src/app/api/getClubByCoords/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: Request) {
 
         // Query database correctly
         const result = await query(
-            "SELECT id, name, description FROM clubs WHERE coordinates ~= point($1, $2)",
+            "SELECT id, name, description, start_time, end_time FROM clubs WHERE coordinates ~= point($1, $2)",
             [x, y]
         );
 

--- a/jumbohack2025/src/app/api/getExistingClubs/route.ts
+++ b/jumbohack2025/src/app/api/getExistingClubs/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
     const eventId = body.eventID;
     console.log(eventId)
     const result = await query(
-      'SELECT id, name, category, coordinates FROM clubs WHERE event_id = $1 AND coordinates IS NOT NULL',
+      'SELECT id, name, category, coordinates, start_time, end_time FROM clubs WHERE event_id = $1 AND coordinates IS NOT NULL',
       [eventId]
     );
     return NextResponse.json(result.rows);
@@ -15,4 +15,4 @@ export async function POST(request: Request) {
     console.error('Error fetching clubs:', error);
     return NextResponse.json({ message: 'Error fetching clubs' }, { status: 500 });
   }
-}
+};

--- a/jumbohack2025/src/app/api/processExcel/route.ts
+++ b/jumbohack2025/src/app/api/processExcel/route.ts
@@ -15,11 +15,6 @@ export async function POST(request: Request) {
       return NextResponse.json({ message: 'No file uploaded' }, { status: 400 });
     }
 
-    console.log('Received file:', file.name);
-    console.log('Timed Table:', timedTable);
-    console.log('Fallback Start Time:', fallbackStartTime);
-    console.log('Fallback End Time:', fallbackEndTime);
-
     // Get the latest event_id from the database
     const result = await query('SELECT MAX(id) as max_id FROM event', []);
     const nextEventId = (result.rows[0]?.max_id ?? 0);

--- a/jumbohack2025/src/app/api/processExcel/route.ts
+++ b/jumbohack2025/src/app/api/processExcel/route.ts
@@ -36,12 +36,12 @@ export async function POST(request: Request) {
       const [name, category, contact, description, start_time, end_time]: ClubRow = row as ClubRow;
       return {
         name,
-        category,
         contact,
         description: description || '', // Default empty string if undefined
+        category,
+        event_id: nextEventId, // Dynamic event ID
         coordinates: null, // Coordinates are null initially
         confirmed: false, // Not confirmed
-        event_id: nextEventId, // Dynamic event ID
         start_time: timedTable && start_time ? start_time : fallbackStartTime, // Fallback to event times if empty
         end_time: timedTable && end_time ? end_time : fallbackEndTime, // Fallback to event times if empty
       };
@@ -53,8 +53,6 @@ export async function POST(request: Request) {
         'INSERT INTO clubs (name, contact, description, category, event_id, coordinates, confirmed, start_time, end_time) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
         [
           club.name,
-          club.category,
-          club.event_id,
           club.contact,
           club.description,
           club.category,

--- a/jumbohack2025/src/app/api/processExcel/route.ts
+++ b/jumbohack2025/src/app/api/processExcel/route.ts
@@ -8,12 +8,17 @@ export async function POST(request: Request) {
     const formData = await request.formData();
     const file = formData.get('file') as File;
     const timedTable = formData.get('timedTable') as string;
-    const fallbackStartTime = formData.get('startTime') as string;
-    const fallbackEndTime = formData.get('endTime') as string;
+    const fallbackStartTime = formData.get('fallbackStartTime') as string;
+    const fallbackEndTime = formData.get('fallbackEndTime') as string;
 
     if (!file) {
       return NextResponse.json({ message: 'No file uploaded' }, { status: 400 });
     }
+
+    console.log('Received file:', file.name);
+    console.log('Timed Table:', timedTable);
+    console.log('Fallback Start Time:', fallbackStartTime);
+    console.log('Fallback End Time:', fallbackEndTime);
 
     // Get the latest event_id from the database
     const result = await query('SELECT MAX(id) as max_id FROM event', []);

--- a/jumbohack2025/src/app/api/processExcelTimed/route.ts
+++ b/jumbohack2025/src/app/api/processExcelTimed/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import * as XLSX from 'xlsx';
+import { query } from '../../../lib/query';
+
+export async function POST(request: Request) {
+  try {
+    // Read the file from the request
+    const formData = await request.formData();
+    const file = formData.get('file') as File;
+
+    if (!file) {
+      return NextResponse.json({ message: 'No file uploaded' }, { status: 400 });
+    }
+
+    // Get the latest event_id from the database
+    const result = await query('SELECT MAX(id) as max_id FROM event', []);
+    const nextEventId = (result.rows[0]?.max_id ?? 0);
+
+    // Convert the file to a buffer
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    // Parse the Excel file
+    const workbook = XLSX.read(buffer, { type: 'buffer' });
+    const sheetName = workbook.SheetNames[0];
+    const sheet = workbook.Sheets[sheetName];
+    const jsonData: unknown[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+
+    // Define a type for rows
+    type ClubRow = [string, string, string, string?]; // name, category, contact, description (optional)
+
+    // Process the data into the desired format
+    const clubs = jsonData.slice(1).map((row) => {
+      const [name, category, contact, description]: ClubRow = row as ClubRow;
+      return {
+        name,
+        category,
+        contact,
+        description: description || '', // Default empty string if undefined
+        coordinates: null, // Coordinates are null initially
+        confirmed: false, // Not confirmed
+        event_id: nextEventId, // Dynamic event ID
+      };
+    });
+
+    // Insert data into the database using the query wrapper
+    for (const club of clubs) {
+      await query(
+        'INSERT INTO clubs (name, category, contact, description, coordinates, confirmed, event_id) VALUES ($1, $2, $3, $4, $5, $6, $7)',
+        [
+          club.name,
+          club.category,
+          club.contact,
+          club.description,
+          club.coordinates,
+          club.confirmed,
+          club.event_id
+        ]
+      );
+    }
+
+    // Return the processed data
+    return NextResponse.json({ 
+      message: 'Data uploaded successfully', 
+      clubs,
+      eventId: nextEventId 
+    });
+  } catch (error) {
+    console.error('Error processing file:', error);
+    return NextResponse.json({ 
+      message: 'Error processing file', 
+      error: (error as Error).message 
+    }, { status: 500 });
+  }
+}

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -302,7 +302,6 @@ export default function CreateEventPage() {
           // Call the excel processing API here
           if (formData.spreadsheet) {
               await processExcel(formData.spreadsheet);
-            // }
           }
           const result = await response.json();
           const eventId = result.eventId + 1;

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -491,11 +491,12 @@ export default function CreateEventPage() {
               {/* Table and Location Title */}
               <div className="pt-4 mb-3 flex items-center justify-between">
                 <h2 className="text-lg font-bold font-serif text-primary">Table and Location Information</h2>
-                                  {/* Timed Table Toggle */}
+                  {/* Timed Table Toggle */}
                   <div className="flex items-center space-x-4">
                     <span className="text-sm font-serif">Toggle Timed Tables</span>
 
                     <button
+                      type="button" // To prevent form thinking this is a submit
                       onClick={() => setTimedTable(!timedTable)}
                       className={`relative w-16 h-8 flex items-center rounded-full p-1 transition-colors duration-300 ${
                         timedTable ? "bg-blue-600" : "bg-gray-400"

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -493,13 +493,13 @@ export default function CreateEventPage() {
                 <h2 className="text-lg font-bold font-serif text-primary">Table and Location Information</h2>
                   {/* Timed Table Toggle */}
                   <div className="flex items-center space-x-4">
-                    <span className="text-sm font-serif">Toggle Timed Tables</span>
+                    <span className="text-sm text-primary">Toggle Timed Tables</span>
 
                     <button
                       type="button" // To prevent form thinking this is a submit
                       onClick={() => setTimedTable(!timedTable)}
-                      className={`relative w-16 h-8 flex items-center rounded-full p-1 transition-colors duration-300 ${
-                        timedTable ? "bg-blue-600" : "bg-gray-400"
+                      className={`relative w-[4rem] h-[1.75rem] flex items-center rounded-full p-1 transition-colors duration-300 ${
+                        timedTable ? "bg-[#2E73B5]" : "bg-gray-400"
                       }`}
                     >
                       <span

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -492,8 +492,8 @@ export default function CreateEventPage() {
               <div className="pt-4 mb-3 flex items-center justify-between">
                 <h2 className="text-lg font-bold font-serif text-primary">Table and Location Information</h2>
                   {/* Timed Table Toggle */}
-                  <div className="flex items-center space-x-4">
-                    <span className="text-sm text-primary">Toggle Timed Tables</span>
+                  <div className="flex items-center space-x-3">
+                    <span className="text-sm font-serif font-medium">Toggle Timed Tables</span>
 
                     <button
                       type="button" // To prevent form thinking this is a submit

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -26,6 +26,7 @@ export default function CreateEventPage() {
   const { user } = useUser();
   const userEmail = user?.emailAddresses[0];
   const [showMap, setShowMap] = useState(false);
+  const [timedTable, setTimedTable] = useState(false);
   const [formData, setFormData] = useState({
     eventName: "",
     date: "",
@@ -354,10 +355,15 @@ export default function CreateEventPage() {
         <div>
           <div className="mb-3">
             <h1 className="text-2xl font-bold font-serif text-primary">Create Event</h1>
+            <hr className="my-4 border-t border-gray-300" />
           </div>
 
           <div>
             <form onSubmit={handleSubmit} className="space-y-2">
+              {/* Event Title */}
+              <div className="mb-3">
+                <h2 className="text-lg font-bold font-serif text-primary">Event Information</h2>
+              </div>
               {/* EVENT NAME */}
               <div className="space-y-1">
                 <label className="text-sm text-primary flex items-center">
@@ -482,9 +488,45 @@ export default function CreateEventPage() {
                 </p>
               </div>
 
+              {/* Table and Location Title */}
+              <div className="pt-4 mb-3 flex items-center justify-between">
+                <h2 className="text-lg font-bold font-serif text-primary">Table and Location Information</h2>
+                                  {/* Timed Table Toggle */}
+                  <div className="flex items-center space-x-4">
+                    <span className="text-sm font-serif">Toggle Timed Tables</span>
+
+                    <button
+                      onClick={() => setTimedTable(!timedTable)}
+                      className={`relative w-16 h-8 flex items-center rounded-full p-1 transition-colors duration-300 ${
+                        timedTable ? "bg-blue-600" : "bg-gray-400"
+                      }`}
+                    >
+                      <span
+                        className={`absolute left-2 text-xs text-white font-bold transition-all duration-300 ${
+                          timedTable ? "opacity-100" : "opacity-0"
+                        }`}
+                      >
+                        ON
+                      </span>
+                      <span
+                        className={`absolute right-2 text-xs text-white font-bold transition-all duration-300 ${
+                          timedTable ? "opacity-0" : "opacity-100"
+                        }`}
+                      >
+                        OFF
+                      </span>
+                      <span
+                        className={`h-6 w-6 bg-white rounded-full shadow-md transform transition-transform duration-300 ${
+                          timedTable ? "translate-x-8" : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
+              </div>
+
               {/* SPREADSHEET */}
               <div className="space-y-1">
-                <div className="flex items-center gap-3">
+                <div className="flex items-between gap-3">
                   <label className="text-sm text-primary flex items-center">
                     Select Spreadsheet*
                     {errors.spreadsheet && (

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -498,7 +498,7 @@ export default function CreateEventPage() {
                     <button
                       type="button" // To prevent form thinking this is a submit
                       onClick={() => setTimedTable(!timedTable)}
-                      className={`relative w-[4rem] h-[1.75rem] flex items-center rounded-full p-1 transition-colors duration-300 ${
+                      className={`relative w-[4rem] h-[1.8rem] flex items-center rounded-full p-1 transition-colors duration-300 ${
                         timedTable ? "bg-[#2E73B5]" : "bg-gray-400"
                       }`}
                     >

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -355,7 +355,6 @@ export default function CreateEventPage() {
       }
 
       const data = await response.json();
-      console.log("Excel processing result:", data);
     } catch (error) {
       console.error("Error processing Excel file:", error);
       toast.error("Error processing Excel file. Please try again.");
@@ -378,7 +377,6 @@ export default function CreateEventPage() {
       }
 
       const data = await response.json();
-      console.log("Excel processing result:", data);
     } catch (error) {
       console.error("Error processing Excel file:", error);
       toast.error("Error processing Excel file. Please try again.");

--- a/jumbohack2025/src/app/events/create/page.tsx
+++ b/jumbohack2025/src/app/events/create/page.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@clerk/nextjs";
 import { redirect } from "next/navigation";
 
 import Tooltip from "@/components/tooltip";
+import { time } from "console";
 
 export default function CreateEventPage() {
   const { userId } = useAuth();
@@ -287,7 +288,11 @@ export default function CreateEventPage() {
         success: async (response) => {
           // Call the excel processing API here
           if (formData.spreadsheet) {
-            await processExcel(formData.spreadsheet);
+            if (timedTable) {
+              await processExcelTimed(formData.spreadsheet);
+            } else {
+              await processExcel(formData.spreadsheet);
+            }
           }
           const result = await response.json();
           const eventId = result.eventId + 1;
@@ -322,12 +327,36 @@ export default function CreateEventPage() {
     }
   };
   
+  // Function to process Excel file WITHOUT timed tables
   const processExcel = async (file: File) => {
     const formData = new FormData();
     formData.append("file", file);
 
     try {
       const response = await fetch("/api/processExcel", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to process Excel file");
+      }
+
+      const data = await response.json();
+      console.log("Excel processing result:", data);
+    } catch (error) {
+      console.error("Error processing Excel file:", error);
+      toast.error("Error processing Excel file. Please try again.");
+    }
+  };
+
+  // Function to process Excel file WITH timed tables
+  const processExcelTimed = async (file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const response = await fetch("/api/processExcelTimed", {
         method: "POST",
         body: formData,
       });

--- a/jumbohack2025/src/app/mapview/[eventID]/page.tsx
+++ b/jumbohack2025/src/app/mapview/[eventID]/page.tsx
@@ -25,6 +25,8 @@ interface ClubInfo {
   id: number;
   name: string;
   description: string;
+  start_time: string;
+  end_time: string;
 }
 
 mapboxgl.accessToken = "pk.eyJ1Ijoic2FsbW9uLXN1c2hpIiwiYSI6ImNtN2dqYWdrZzA4ZnIyam9qNWx1NnAybjcifQ._YD8GYWPtpZ09AwYHzR2Og";
@@ -210,7 +212,7 @@ export default function MapboxMap() {
             const { lng, lat } = marker.getLngLat();
             const club = await getClubByCoords(lng, lat);
             if (club) {
-              setClubInfo({ id: club.id, name: club.name, description: club.description });
+              setClubInfo({ id: club.id, name: club.name, description: club.description, start_time: club.start_time, end_time: club.end_time });
               setShowClubInfo(true);
             }
           });
@@ -274,6 +276,8 @@ export default function MapboxMap() {
               id: clubData.id,
               name: clubData.name,
               description: clubData.description,
+              start_time: clubData.start_time,
+              end_time: clubData.end_time,
             });
             setShowClubInfo(true);
           }
@@ -339,6 +343,8 @@ export default function MapboxMap() {
                 id: clubData.id,
                 name: clubData.name,
                 description: clubData.description,
+                start_time: clubData.start_time,
+                end_time: clubData.end_time,
               });
               setShowClubInfo(true);
             }

--- a/jumbohack2025/src/app/mapview/[eventID]/page.tsx
+++ b/jumbohack2025/src/app/mapview/[eventID]/page.tsx
@@ -13,6 +13,8 @@ interface Club {
   name: string;
   category: string;
   description: string;
+  start_time?: string;
+  end_time?: string;
   coordinates?: {
     x: number;
     y: number;
@@ -184,11 +186,15 @@ export default function MapboxMap() {
 
           if (!response.ok) {
             console.error("Error fetching existing clubs.");
+            return [];
           }
 
-          return await response.json();
+          const data = await response.json();
+          console.log("Raw API response from getExistingClubs:", data);
+          return data;
         } catch (error) {
           console.error("Error fetching clubs:", error);
+          return [];
         }
       };
 

--- a/jumbohack2025/src/components/ClubInfo.tsx
+++ b/jumbohack2025/src/components/ClubInfo.tsx
@@ -8,6 +8,8 @@ interface Club {
   id: number;
   name: string;
   description: string;
+  start_time: string;
+  end_time: string;
 }
 
 interface InfoPopupProps {
@@ -40,6 +42,8 @@ export default function InfoPopup({ club, onClose }: InfoPopupProps) {
       {/* Club Info */}
       <h2 className="text-lg font-bold">{club.name}</h2>
       <p className="text-gray-600">{club.description}</p>
+      <p className="text-gray-900">{club.start_time}</p>
+      <p className="text-gray-900">{club.end_time}</p>
       </motion.div>
     </div>
   );

--- a/jumbohack2025/src/components/ClubInfo.tsx
+++ b/jumbohack2025/src/components/ClubInfo.tsx
@@ -18,6 +18,29 @@ interface InfoPopupProps {
 }
 
 export default function InfoPopup({ club, onClose }: InfoPopupProps) {
+  // Helper function to format time (e.g., "14:30:00" -> "2:30 PM")
+  const formatTime = (timeString: string) => {
+    if (!timeString) return "Not specified";
+    
+    try {
+      // If it's already in a good format, return as is
+      if (timeString.includes("AM") || timeString.includes("PM")) {
+        return timeString;
+      }
+      
+      // Convert "HH:MM:SS" or "HH:MM" to 12-hour format
+      const [hours, minutes] = timeString.split(':');
+      const hour24 = parseInt(hours);
+      const hour12 = hour24 === 0 ? 12 : hour24 > 12 ? hour24 - 12 : hour24;
+      const ampm = hour24 >= 12 ? 'PM' : 'AM';
+      
+      return `${hour12}:${minutes} ${ampm}`;
+    } catch (error) {
+      // If parsing fails, return the original string
+      return timeString;
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 flex items-end justify-center bg-black/50"
@@ -41,9 +64,20 @@ export default function InfoPopup({ club, onClose }: InfoPopupProps) {
 
       {/* Club Info */}
       <h2 className="text-lg font-bold">{club.name}</h2>
-      <p className="text-gray-600">{club.description}</p>
-      <p className="text-gray-900">{club.start_time}</p>
-      <p className="text-gray-900">{club.end_time}</p>
+      <p className="text-gray-600 mb-3">{club.description}</p>
+      
+      {/* Timing Information */}
+      <div className="border-t pt-3">
+        <h3 className="text-sm font-semibold text-gray-800 mb-2">Event Times</h3>
+        <div className="space-y-1">
+          <p className="text-sm text-gray-700">
+            <span className="font-medium">Start:</span> {formatTime(club.start_time)}
+          </p>
+          <p className="text-sm text-gray-700">
+            <span className="font-medium">End:</span> {formatTime(club.end_time)}
+          </p>
+        </div>
+      </div>
       </motion.div>
     </div>
   );

--- a/jumbohack2025/src/components/ClubInfo.tsx
+++ b/jumbohack2025/src/components/ClubInfo.tsx
@@ -70,12 +70,14 @@ export default function InfoPopup({ club, onClose }: InfoPopupProps) {
       <div className="border-t pt-3">
         <h3 className="text-sm font-semibold text-gray-800 mb-2">Event Times</h3>
         <div className="space-y-1">
-          <p className="text-sm text-gray-700">
-            <span className="font-medium">Start:</span> {formatTime(club.start_time)}
-          </p>
-          <p className="text-sm text-gray-700">
-            <span className="font-medium">End:</span> {formatTime(club.end_time)}
-          </p>
+          <div className="flex gap-4 text-sm text-gray-700">
+            <p>
+              <span className="font-medium">Start:</span> {formatTime(club.start_time)}
+            </p>
+            <p>
+              <span className="font-medium">End:</span> {formatTime(club.end_time)}
+            </p>
+          </div>
         </div>
       </div>
       </motion.div>


### PR DESCRIPTION
#38 

### Features:
- Bye bye duration, hello end_time. On "Create an Event," changed time to start_time and duration to end_time on submission form. Also added toggle to enable timed tables. Also updated Neon db accordingly. 
- Adding times to spreadsheet parser. Cells must be formatted as Date & Time in Excel, and then processExcel will deconstruct the serialized float for date and extract the time into a "time without time zone" format. Fallback is event start and end time.
- On Map view, updated ClubInfo popup from pins to include the start and end times. 
- Did not add feature to disable pins only when current time is within their visibility window.